### PR TITLE
Set h2 alpn for openssl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1517,7 +1517,7 @@ dependencies = [
 
 [[package]]
 name = "tonic-clap"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "bevy_reflect",
  "clap",

--- a/tonic-clap/Cargo.toml
+++ b/tonic-clap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tonic-clap"
-version = "0.2.4"
+version = "0.2.5"
 edition.workspace = true
 license.workspace = true
 documentation.workspace = true

--- a/tonic-clap/src/arg/openssl.rs
+++ b/tonic-clap/src/arg/openssl.rs
@@ -93,6 +93,9 @@ impl OpensslArgs {
             ok
         });
 
+        // Enable ALPN for HTTP/2
+        builder.set_alpn_protos(tonic_tls::openssl::ALPN_H2_WIRE)?;
+
         Ok(builder)
     }
 }


### PR DESCRIPTION
dotnet server requires alpn to be set for interoperability.